### PR TITLE
Bump bounds

### DIFF
--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,0 +1,29 @@
+# For more information, see: https://github.com/commercialhaskell/stack/wiki/stack.yaml
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-9.21
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,0 +1,29 @@
+# For more information, see: https://github.com/commercialhaskell/stack/wiki/stack.yaml
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-11.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.0.yaml
+stack-8.2.yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-7.10.yaml
+stack-8.0.yaml

--- a/tasty-dumbcheck.cabal
+++ b/tasty-dumbcheck.cabal
@@ -25,7 +25,7 @@ library
   ghc-options:         -Wall
   exposed-modules:     Test.DumbCheck
                        Test.Tasty.DumbCheck
-  build-depends:       base >=4.6 && <4.9,
+  build-depends:       base >=4.6 && <4.10,
                        tasty
   if impl(ghc < 7.8)
      build-depends:    tagged >=0.7.2
@@ -36,6 +36,6 @@ test-suite tasty
   hs-source-dirs:      tests
   main-is:             tasty.hs
   ghc-options:         -Wall -threaded
-  build-depends:       base >= 4.6 && <4.9,
+  build-depends:       base >= 4.6 && <4.10,
                        tasty >=0.10,
                        tasty-dumbcheck

--- a/tasty-dumbcheck.cabal
+++ b/tasty-dumbcheck.cabal
@@ -25,7 +25,7 @@ library
   ghc-options:         -Wall
   exposed-modules:     Test.DumbCheck
                        Test.Tasty.DumbCheck
-  build-depends:       base >=4.6 && <4.11,
+  build-depends:       base >=4.6 && <4.12,
                        tasty
   if impl(ghc < 7.8)
      build-depends:    tagged >=0.7.2
@@ -36,6 +36,6 @@ test-suite tasty
   hs-source-dirs:      tests
   main-is:             tasty.hs
   ghc-options:         -Wall -threaded
-  build-depends:       base >= 4.6 && <4.11,
+  build-depends:       base >= 4.6 && <4.12,
                        tasty >=0.10,
                        tasty-dumbcheck

--- a/tasty-dumbcheck.cabal
+++ b/tasty-dumbcheck.cabal
@@ -25,7 +25,7 @@ library
   ghc-options:         -Wall
   exposed-modules:     Test.DumbCheck
                        Test.Tasty.DumbCheck
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        tasty
   if impl(ghc < 7.8)
      build-depends:    tagged >=0.7.2
@@ -36,6 +36,6 @@ test-suite tasty
   hs-source-dirs:      tests
   main-is:             tasty.hs
   ghc-options:         -Wall -threaded
-  build-depends:       base >= 4.6 && <4.10,
+  build-depends:       base >= 4.6 && <4.11,
                        tasty >=0.10,
                        tasty-dumbcheck


### PR DESCRIPTION
Now supporting GHC 8.0, GHC 8.2, and GHC 8.4.

* Bumped the bounds to include the corresponding versions of `base`
* Added `stack-8.0.yaml` and `stack-8.2.yaml` (no `stack-8.4.yaml` because GHC 8.4 is not in any lts yet, only in nightly)
* Pointing `stack.yaml` to `stack-8.2.yaml`